### PR TITLE
Update all decoders to compile on macOS

### DIFF
--- a/Aqua Decoder/CMakeLists.txt
+++ b/Aqua Decoder/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required (VERSION 3.0.0)
 project (AQUADecoder)
 file(GLOB_RECURSE AQUADecoder_CPPS src/*.cpp)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
 add_executable(AQUADecoder ${AQUADecoder_CPPS})
 
 target_include_directories(AQUADecoder PUBLIC src)

--- a/Aqua MODIS Extractor/CMakeLists.txt
+++ b/Aqua MODIS Extractor/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required (VERSION 3.0.0)
 project (AQUA-MODIS-Extractor)
 file(GLOB_RECURSE AQUA-MODIS-Extractor_CPPS src/*.cpp)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
+
 add_executable(AQUA-MODIS-Extractor ${AQUA-MODIS-Extractor_CPPS})
 
 target_include_directories(AQUA-MODIS-Extractor PUBLIC src)

--- a/CADU Synchroderand/CMakeLists.txt
+++ b/CADU Synchroderand/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required (VERSION 3.0.0)
 project (CADU-Synchroderand)
 file(GLOB_RECURSE CADU-Synchroderand_CPPS src/*.cpp)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
+
 add_executable(CADU-Synchroderand ${CADU-Synchroderand_CPPS})
 
 target_include_directories(CADU-Synchroderand PUBLIC src)

--- a/ELEKTRO-L Decoder/CMakeLists.txt
+++ b/ELEKTRO-L Decoder/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required (VERSION 3.0.0)
 project (ELEKTRO-L-Decoder)
 file(GLOB_RECURSE ELEKTRO-L-Decoder_CPPS src/*.cpp src/viterbi_lib/metrics.c src/viterbi_lib/tab.c src/viterbi_lib/viterbi.c)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
+
 add_executable(ELEKTRO-L-Decoder ${ELEKTRO-L-Decoder_CPPS})
 
 target_include_directories(ELEKTRO-L-Decoder PUBLIC src)

--- a/FengYun 3D Decoder/CMakeLists.txt
+++ b/FengYun 3D Decoder/CMakeLists.txt
@@ -4,6 +4,12 @@ project (FY3DDecoder)
 
 file(GLOB_RECURSE FY3DDecoder_CPPS src/*.cpp src/viterbi_lib/metrics.c src/viterbi_lib/tab.c src/viterbi_lib/viterbi.c)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
+
 add_executable(FY3DDecoder ${FY3DDecoder_CPPS})
 
 target_include_directories(FY3DDecoder PUBLIC src)

--- a/FengYun MPT Decoder/CMakeLists.txt
+++ b/FengYun MPT Decoder/CMakeLists.txt
@@ -4,6 +4,12 @@ project (FengYun-MPT-Decoder)
 
 file(GLOB_RECURSE FengYun-MPT-Decoder_CPPS src/*.cpp src/viterbi_lib/metrics.c src/viterbi_lib/tab.c src/viterbi_lib/viterbi.c)
 
+if(APPLE)
+    include_directories(/usr/local/include)
+    link_directories(/usr/local/lib)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
+
 add_executable(FengYun-MPT-Decoder ${FengYun-MPT-Decoder_CPPS})
 
 target_include_directories(FengYun-MPT-Decoder PUBLIC src)


### PR DESCRIPTION
Just like the AQUA decoder, all the other ones require the same update to CMakeLists.txt
Tested and working on macOS 10.15.6